### PR TITLE
AC-38: Support deploying applications with names different to archive name

### DIFF
--- a/payara-managed/pom.xml
+++ b/payara-managed/pom.xml
@@ -136,6 +136,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+        <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+        <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+        <scope>test</scope>
+      </dependency>
 
     </dependencies>
 
@@ -196,6 +206,15 @@
                 <glassfish.home>payara41</glassfish.home>
             </properties>
         </profile>
+      <profile>
+        <id>payara-5</id>
+        <properties>
+          <groupId>fish.payara.distributions</groupId>
+          <artifactId>payara</artifactId>
+          <version.payara>5.192</version.payara>
+          <glassfish.home>payara5</glassfish.home>
+        </properties>
+      </profile>
     </profiles>
 
 </project>

--- a/payara-managed/src/test/java/fish/payara/arquillian/container/payara/managed/PayaraEarWithNameTest.java
+++ b/payara-managed/src/test/java/fish/payara/arquillian/container/payara/managed/PayaraEarWithNameTest.java
@@ -1,0 +1,72 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.container.payara.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.descriptor.api.application6.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class PayaraEarWithNameTest extends GlassFishManagedDeploymentTestTemplate {
+
+    @Deployment(testable = false)
+    public static EnterpriseArchive earWithName() {
+        EnterpriseArchive enterpriseArchive = ShrinkWrap.create(EnterpriseArchive.class);
+
+        StringAsset applicationXml = new StringAsset(Descriptors.create(ApplicationDescriptor.class)
+            .version("6")
+            // not only we give it name different from archive name, we give it name that doesn't coerce to String
+            .applicationName("true").getOrCreateModule().getOrCreateWeb().webUri("test1.war")
+            .contextRoot("/test1").up().up().exportAsString());
+        enterpriseArchive.setApplicationXML(applicationXml);
+
+        enterpriseArchive.addAsModule(ShrinkWrap.create(WebArchive.class, "test1.war")
+            .merge(GlassFishManagedDeployWarTest.getTestArchive()));
+        return enterpriseArchive;
+    }
+}

--- a/payara-remote/src/test/java/fish/payara/arquillian/container/payara/remote/PayaraRestDeployEarWithNameTest.java
+++ b/payara-remote/src/test/java/fish/payara/arquillian/container/payara/remote/PayaraRestDeployEarWithNameTest.java
@@ -1,0 +1,102 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+package fish.payara.arquillian.container.payara.remote;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.annotation.WebServlet;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.logging.Logger;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies arquillian tests can run in client mode with this REST based container.
+ *
+ * @author <a href="http://community.jboss.org/people/aslak">Aslak Knutsen</a>
+ * @author <a href="http://community.jboss.org/people/LightGuard">Jason Porter</a>
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@RunWith(Arquillian.class)
+public class PayaraRestDeployEarWithNameTest {
+    
+    private static final Logger log = Logger.getLogger(PayaraRestDeployEarWithNameTest.class.getName());
+
+    /**
+     * Deployment for the test
+     */
+    @Deployment(testable = false)
+    public static Archive<?> getTestArchive() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war")
+            .addClasses(GreeterServlet.class);
+        final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "test.jar")
+            .addClasses(Greeter.class);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class)
+            .setApplicationXML("application-with-name.xml")
+            .addAsModule(war)
+            .addAsModule(ejb);
+        log.info(ear.toString(true));
+        return ear;
+    }
+
+    @Test
+    public void shouldBeAbleToDeployEnterpriseArchive() throws Exception {
+        final String servletPath = GreeterServlet.class.getAnnotation(WebServlet.class).value()[0];
+
+        final URLConnection response = new URL("http://localhost:8080/test" + servletPath).openConnection();
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(response.getInputStream()));
+        final String result = in.readLine();
+
+        assertThat(result, equalTo("Hello"));
+    }
+}

--- a/payara-remote/src/test/resources/application-with-name.xml
+++ b/payara-remote/src/test/resources/application-with-name.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="6"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd">
+  <!-- Just to test, that client doesn't try to parse properties in a smart way, this should be a String -->
+  <application-name>20190809</application-name>
+  <module>
+    <web>
+      <web-uri>test.war</web-uri>
+      <context-root>/test</context-root>
+    </web>
+  </module>
+  <module>
+    <ejb>test.jar</ejb>
+  </module>
+</application>


### PR DESCRIPTION
Deployment descriptors might prescribe a name for application and server respects that. 
That resulted in Arquillian deployment failing, as the application was registered under different name than expected