### PR TITLE
[PAYARA-4150] - Micro Container Updates

### DIFF
--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -52,6 +52,10 @@ public class PayaraVersion {
         }
         this.versionString = versionString;
     }
+    
+    public boolean isMoreRecentThan(String versionString) {
+        return isMoreRecentThan(new PayaraVersion(versionString));
+    }
 
     /**
      * A Utility method used for comparing PayaraVersion objects

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -53,6 +53,15 @@ public class PayaraVersion {
         this.versionString = versionString;
     }
 
+    /**
+     * A Utility method used for comparing PayaraVersion objects
+     * 
+     * When the parsed PayaraVersion is equal to the version it's being compared
+     * to, the method will return true
+     * 
+     * @param minimum - the version you wish to compare to
+     * @return true if minimum is equal to or greater than the version to compare
+     */
     public boolean isMoreRecentThan(PayaraVersion minimum) {
         String minString = minimum.versionString;
         try (Scanner minScanner = new Scanner(minString); Scanner vScanner = new Scanner(versionString)) {
@@ -83,7 +92,7 @@ public class PayaraVersion {
                     vPart--;
                 }
 
-                if (vPart > minPart) {
+                if (vPart >= minPart) {
                     return true;
                 }
                 if (minPart > vPart) {

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -135,8 +135,8 @@ public class PayaraVersion {
                     vPart--;
                 }
 
-                if (vPart >= minPart) {
-                    continue;
+                if (vPart > minPart) {
+                    return true;
                 }
                 if (minPart > vPart) {
                     return false;

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -53,6 +53,45 @@ public class PayaraVersion {
         this.versionString = versionString;
     }
     
+    /**
+     * This Method takes in properties from a glassfish-version.properties file and constructs
+     * a new PayaraVersion object from this data. It is assumed that there will always be a
+     * major and minor version but update, payaraMajor and payaraMinor may be null.
+     * 
+     * @param major - Major version of the server
+     * @param minor - Minor version of the server
+     * @param update - Stability/Feature patch version of the server
+     * @param payaraMinor - Minor version of Payara 4 versions
+     * @param payaraUpdate - Stability/Feat patch version of Payara 4 versions
+     * @return 
+     */
+    public static PayaraVersion buildVersionFromBrandingProperties(String major, String minor, String update, 
+                                                                    String payaraMinor, String payaraUpdate)
+                                                                    throws IllegalArgumentException {
+        StringBuilder versionBuilder = new StringBuilder();
+        String[] subVersionValues = {minor, update, payaraMinor, payaraUpdate};
+        
+        if(major == null || major.isEmpty()) {
+            throw new IllegalArgumentException("Invalid properties - Major version value cannot be null or empty.");
+        }
+        
+        versionBuilder.append(major); //should always be a major version with value
+        
+        for(int i = 0; i < subVersionValues.length; i++) {
+            
+            String curVersionValue = subVersionValues[i];
+            
+            if(curVersionValue != null && !curVersionValue.isEmpty()) {
+                versionBuilder.append(".");
+                versionBuilder.append(curVersionValue);
+            } else {
+                break;
+            }
+        }
+        
+        return new PayaraVersion(versionBuilder.toString());
+    }
+    
     public boolean isMoreRecentThan(String versionString) {
         return isMoreRecentThan(new PayaraVersion(versionString));
     }
@@ -97,7 +136,7 @@ public class PayaraVersion {
                 }
 
                 if (vPart >= minPart) {
-                    return true;
+                    continue;
                 }
                 if (minPart > vPart) {
                     return false;
@@ -105,5 +144,10 @@ public class PayaraVersion {
             }
         }
         return true;
+    }
+    
+    @Override
+    public String toString() {
+        return versionString;
     }
 }

--- a/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
+++ b/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
@@ -37,6 +37,7 @@
  */
 package fish.payara.arquillian.container.payara;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -75,5 +76,33 @@ public class PayaraVersionTest {
         v1 = new PayaraVersion("5.181-SNAPSHOT");
         v2 = new PayaraVersion("5.181");
         assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+    }
+    
+    @Test
+    public void testVersionBuilderFromProperties() {
+    
+        PayaraVersion testVersion = PayaraVersion.buildVersionFromBrandingProperties("5", "192", "", "", "");
+        assertEquals("5.192", testVersion.toString());
+        
+        testVersion = PayaraVersion.buildVersionFromBrandingProperties("5", "192", "3", "", "");
+        assertEquals("5.192.3", testVersion.toString());
+        
+        testVersion = PayaraVersion.buildVersionFromBrandingProperties("4", "1", "2", null, null);
+        assertEquals("4.1.2", testVersion.toString());
+        
+        testVersion = PayaraVersion.buildVersionFromBrandingProperties("4", "1", "2", "191", "");
+        assertEquals("4.1.2.191", testVersion.toString());
+        
+        testVersion = PayaraVersion.buildVersionFromBrandingProperties("4", "1", "2", "191", "7");
+        assertEquals("4.1.2.191.7", testVersion.toString());
+        
+        testVersion = PayaraVersion.buildVersionFromBrandingProperties("4", "1", null, "191", "7");
+        assertEquals("4.1", testVersion.toString());
+    
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void whenMajorValueIsNull_thanExpectIllegalArgument() {
+        PayaraVersion testVersion = PayaraVersion.buildVersionFromBrandingProperties(null, "192", "", "", "");
     }
 }

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -199,21 +199,20 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
             throw new IllegalArgumentException("Could not locate the Payara Micro Jar file " + getMicroJar());
         }
 
+        String zipEntryDir = ""; //Created here for the sakes of debugging in case of NPE
+        
         try (JarFile microJarFile = new JarFile(getMicroJarFile())) {
             
-            //Change made to accommodate package refactor in version 5.194+
-            String zipEntryDir = (getMicroVersion().isMoreRecentThan("5.194-SNAPSHOT")) 
-                    ? "META-INF/maven/fish.payara.server.internal.extras/payara-micro-boot/pom.properties" 
-                    : "META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties";
-            
+            zipEntryDir = "MICRO-INF/domain/branding/glassfish-version.properties";
             ZipEntry pomProperties = microJarFile.getEntry(zipEntryDir);
+
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
-            this.microVersion = new PayaraVersion(microProperties.getProperty("version"));
+            this.microVersion = new PayaraVersion(microProperties.getProperty("major_version") + microProperties.getProperty("minor_version"));
         } catch (IOException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.", e);
-        } catch (IllegalStateException e) {
+                    "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar." + zipEntryDir, e);
+        } catch (NullPointerException e) {
             throw new IllegalArgumentException(
                     "Unable to find Payara Micro Boot Properties. Are you using the latest arquillian container?", e);
         }

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -211,10 +211,10 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
             this.microVersion = new PayaraVersion(microProperties.getProperty("major_version") + microProperties.getProperty("minor_version"));
         } catch (IOException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar." + zipEntryDir, e);
+                    "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.", e);
         } catch (NullPointerException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Boot Properties. Are you using the latest arquillian container?", e);
+                    "Unable to find Payara Micro Boot Properties. Are you using the latest arquillian container? \n Directory searched: " + zipEntryDir, e);
         }
         notNull(getMicroVersion(), "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.");
 

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -199,22 +199,22 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
             throw new IllegalArgumentException("Could not locate the Payara Micro Jar file " + getMicroJar());
         }
 
-        String zipEntryDir = ""; //Created here for the sakes of debugging in case of NPE
+        String zipEntryFileDir = ""; //Created here for the sakes of debugging in case of NPE
         
         try (JarFile microJarFile = new JarFile(getMicroJarFile())) {
             
-            zipEntryDir = "MICRO-INF/domain/branding/glassfish-version.properties";
-            ZipEntry pomProperties = microJarFile.getEntry(zipEntryDir);
+            zipEntryFileDir = "MICRO-INF/domain/branding/glassfish-version.properties";
+            ZipEntry pomProperties = microJarFile.getEntry(zipEntryFileDir);
 
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
-            this.microVersion = new PayaraVersion(microProperties.getProperty("major_version") + microProperties.getProperty("minor_version"));
+            this.microVersion = new PayaraVersion(microProperties.getProperty("major_version") + "." + microProperties.getProperty("minor_version"));
         } catch (IOException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.", e);
+                    "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.", e);
         } catch (NullPointerException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Boot Properties. Are you using the latest arquillian container? \n Directory searched: " + zipEntryDir, e);
+                    "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.\nProperties File Used: " + zipEntryFileDir, e);
         }
         notNull(getMicroVersion(), "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.");
 

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -73,6 +73,8 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
     private String cmdOptions = getConfigurableVariable("payara.cmdOptions", "MICRO_CMD_OPTIONS", null);
 
     private String extraMicroOptions = getConfigurableVariable("payara.extraMicroOptions", "EXTRA_MICRO_OPTIONS", null);
+    
+    private final String ZIP_ENTRY_FILE_DIR = "MICRO-INF/domain/branding/glassfish-version.properties";
 
     public String getMicroJar() {
         return microJar;
@@ -198,13 +200,10 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
         if (!getMicroJarFile().isFile()) {
             throw new IllegalArgumentException("Could not locate the Payara Micro Jar file " + getMicroJar());
         }
-
-        String zipEntryFileDir = ""; //Created here for the sakes of debugging in case of NPE
         
         try (JarFile microJarFile = new JarFile(getMicroJarFile())) {
             
-            zipEntryFileDir = "MICRO-INF/domain/branding/glassfish-version.properties";
-            ZipEntry pomProperties = microJarFile.getEntry(zipEntryFileDir);
+            ZipEntry pomProperties = microJarFile.getEntry(ZIP_ENTRY_FILE_DIR);
 
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
@@ -214,7 +213,7 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
                     "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.", e);
         } catch (NullPointerException e) {
             throw new IllegalArgumentException(
-                    "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.\nProperties File Used: " + zipEntryFileDir, e);
+                    "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.\nProperties File Used: " + ZIP_ENTRY_FILE_DIR, e);
         }
         notNull(getMicroVersion(), "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.");
 

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -207,7 +207,12 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
 
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
-            this.microVersion = new PayaraVersion(microProperties.getProperty("major_version") + "." + microProperties.getProperty("minor_version"));
+            this.microVersion = PayaraVersion.buildVersionFromBrandingProperties(microProperties.getProperty("major_version"),
+                                                                                 microProperties.getProperty("minor_version"),
+                                                                                 microProperties.getProperty("update_version"),
+                                                                                 microProperties.getProperty("payara_version"),
+                                                                                 microProperties.getProperty("payara_update_version"));
+            
         } catch (IOException e) {
             throw new IllegalArgumentException(
                     "Unable to find Payara Micro Version. Please check the file is a valid Payara Micro Jar.", e);

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -201,7 +201,11 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
 
         try (JarFile microJarFile = new JarFile(getMicroJarFile())) {
             ZipEntry pomProperties = microJarFile
-                    .getEntry("META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties");
+                    .getEntry(
+                            
+                            //TO-DO: Add Version Check Code
+                            
+                            "META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties");
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
             this.microVersion = new PayaraVersion(microProperties.getProperty("version"));

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -200,18 +200,22 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
         }
 
         try (JarFile microJarFile = new JarFile(getMicroJarFile())) {
-            ZipEntry pomProperties = microJarFile
-                    .getEntry(
-                            
-                            //TO-DO: Add Version Check Code
-                            
-                            "META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties");
+            
+            //Change made to accommodate package refactor in version 5.194+
+            String zipEntryDir = (getMicroVersion().isMoreRecentThan("5.194-SNAPSHOT")) 
+                    ? "META-INF/maven/fish.payara.server.internal.extras/payara-micro-boot/pom.properties" 
+                    : "META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties";
+            
+            ZipEntry pomProperties = microJarFile.getEntry(zipEntryDir);
             Properties microProperties = new Properties();
             microProperties.load(microJarFile.getInputStream(pomProperties));
             this.microVersion = new PayaraVersion(microProperties.getProperty("version"));
         } catch (IOException e) {
             throw new IllegalArgumentException(
                     "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.", e);
+        } catch (IllegalStateException e) {
+            throw new IllegalArgumentException(
+                    "Unable to find Payara Micro Boot Properties. Are you using the latest arquillian container?", e);
         }
         notNull(getMicroVersion(), "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.");
 


### PR DESCRIPTION
A recent update to the package naming within Payara Server caused a full break to the micro-managed container caused by the directory of the file with micro boot properties not being the same anymore. This PR updates the container to use the glassfish domain properties which have a consistent directory for the time being.

Tested against Payara 5.193 and 5.194-SNAPSHOT on EE7 and EE8 samples