### PR TITLE
AC-28: Payara Server Managment API (draft)

### DIFF
--- a/payara-management-api/pom.xml
+++ b/payara-management-api/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>parent-payara-containers</artifactId>
+    <groupId>fish.payara.arquillian</groupId>
+    <version>1.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>payara-management-api</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- We're testing basic arquillian functionality here, so we'll just use SE container for that -->
+<!--    <dependency>-->
+<!--      <groupId>org.jboss.arquillian.container</groupId>-->
+<!--      <artifactId>container-se-managed</artifactId>-->
+<!--      <version>1.0.1.Final</version>-->
+<!--      <scope>test</scope>-->
+<!--    </dependency>-->
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-weld-embedded</artifactId>
+      <version>2.0.1.Final</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-core-impl</artifactId>
+      <version>3.1.2.Final</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/CommandResult.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/CommandResult.java
@@ -1,0 +1,75 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management;
+
+/**
+ * Result of asadmin command.
+ * It's a knock off of org.glassfish.embeddable.CommandResult, for which we have no published artifact at this moment
+ * (except for embedded-all. Or another copy in payara-micro)
+ */
+public interface CommandResult {
+    /**
+     * A command can have following types of exit status.
+     */
+    enum ExitStatus {
+        SUCCESS,
+        WARNING,
+        FAILURE
+    }
+
+    /**
+     * @return exit status of the command
+     */
+    ExitStatus getExitStatus();
+
+    /**
+     * @return command output
+     */
+    String getOutput();
+
+    /**
+     * This method returns any exception raised during command invocation, If the command's exit status
+     * is {@link ExitStatus#SUCCESS}, then this method will return null.
+     *
+     * @return any exception that occurred during this command execution.
+     */
+    Throwable getFailureCause();
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/ExternalServerManagement.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/ExternalServerManagement.java
@@ -1,0 +1,87 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management;
+
+import fish.payara.arquillian.management.impl.PayaraManagementExtension;
+import fish.payara.arquillian.management.impl.StaticPayaraManagementLookup;
+
+import java.util.List;
+
+/**
+ * Management operations to be performed from client side, before test run.
+ *
+ */
+public interface ExternalServerManagement {
+    String getAdminHost();
+    int getAdminPort();
+    String getDomainName();
+    String getPayaraVersion();
+
+    boolean isRunning();
+
+    void restartDomain();
+
+    void restartInstance(String instanceName);
+
+    List<String> listInstances();
+
+    /**
+     * A container MAY support running arbitrary commands, e.g. my means of invoking asadmin script or remote REST
+     * interface, the set of supported commands might be limited, or non-existing. For example, Payara micro might
+     * not support those.
+     * @param commandName
+     * @param parameters
+     * @return result of the command
+     * @throws UnsupportedOperationException when container cannot run arbitrary commands outside the server.
+     */
+    CommandResult asadmin(String commandName, String... parameters);
+
+    /**
+     * Register a command to be executed after server startup.
+     * @param commandName
+     * @param parameters
+     */
+    void postBootCommand(String commandName, String... parameters);
+
+    static ExternalServerManagement instance() {
+        return StaticPayaraManagementLookup.externalServerManagement();
+    }
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/ServerManagement.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/ServerManagement.java
@@ -1,0 +1,66 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management;
+
+import fish.payara.arquillian.management.impl.StaticPayaraManagementLookup;
+
+/**
+ * Management Operations to be performed when running inside the server
+ */
+public interface ServerManagement {
+    String getAdminHost();
+    int getAdminPort();
+    String getDomainName();
+    String getPayaraVersion();
+
+    /**
+     * Run arbitrary asadmin command.
+     * Inside the server, an internal service CommandRunner is available which can execute any administrative command
+     * @param commandName
+     * @param options
+     * @return
+     */
+    CommandResult asadmin(String commandName, String... options);
+
+    static ServerManagement instance() {
+        return StaticPayaraManagementLookup.serverManagement();
+    }
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ContainerExtender.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ContainerExtender.java
@@ -1,0 +1,64 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import fish.payara.arquillian.management.ServerManagement;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+class ContainerExtender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "payara-management-api")
+            // public API
+            .addPackage(ServerManagement.class.getPackage())
+            // public API dependencies
+            .addClass(StaticPayaraManagementLookup.class)
+            // remote extension
+            .addClass(ContainerExtension.class)
+            .addAsServiceProvider(RemoteLoadableExtension.class, ContainerExtension.class)
+            // extension dependencies
+            .addClasses();
+    }
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ContainerExtension.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ContainerExtension.java
@@ -1,0 +1,50 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+
+public class ContainerExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.observer(Publisher.class);
+    }
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ExternalServerManagementInjector.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/ExternalServerManagementInjector.java
@@ -1,0 +1,74 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import fish.payara.arquillian.management.ExternalServerManagement;
+import org.jboss.arquillian.container.spi.event.StartClassContainers;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.TestClass;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Inject ExternalServerManagement into static fields of a test class before deploy method is called
+ */
+class ExternalServerManagementInjector {
+    @Inject Instance<ExternalServerManagement> management;
+
+    public void injectExternalServerManagement(@Observes StartClassContainers event, TestClass testClass) {
+        for (Field field : testClass.getJavaClass().getFields()) {
+            if (Modifier.isStatic(field.getModifiers()) && field.getType() == ExternalServerManagement.class) {
+                // todo: accesibility, parent classes, ...
+                // todo: Or consider whether to support such injection at all and not rely on programmatic access only
+                ExternalServerManagement instance = management.get();
+                try {
+                    field.set(null, instance);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/PayaraManagementExtension.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/PayaraManagementExtension.java
@@ -1,0 +1,59 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class PayaraManagementExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.observer(ExternalServerManagementInjector.class)
+            .observer(Publisher.class)
+            .service(AuxiliaryArchiveAppender.class, ContainerExtender.class);
+    }
+
+    public static void registerEmbeddedContainer(ExtensionBuilder extensionBuilder) {
+        new ContainerExtension().register(extensionBuilder);
+    }
+
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/Publisher.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/Publisher.java
@@ -1,0 +1,100 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import fish.payara.arquillian.management.ExternalServerManagement;
+import fish.payara.arquillian.management.ServerManagement;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+class Publisher {
+    @Inject
+    Instance<ExternalServerManagement> externalServerManagement;
+
+    @Inject
+    Instance<ServerManagement> serverManagement;
+
+    @Inject
+    Instance<ServiceLoader> serviceLoader;
+
+    Publisher() {
+        // this is bit to early, but the field will be eventually injected
+        StaticPayaraManagementLookup.serverManagementSupplier = () -> find(ServerManagement.class, serverManagement);
+        StaticPayaraManagementLookup.externalServerManagemenSupplier = () -> find(ExternalServerManagement.class, externalServerManagement);
+    }
+
+    private <T> T find(Class<T> targetType, Instance<T> diSource) {
+        if (diSource == null || serviceLoader == null) {
+            return null;
+        }
+        T result = null;
+        result = diSource.get();
+        if (result == null) {
+            for (ResourceProvider resourceProvider : serviceLoader.get().all(ResourceProvider.class)) {
+                if (resourceProvider.canProvide(targetType)) {
+                    result = targetType.cast(resourceProvider.lookup(new AnnotationResourceLiteral()));
+                    if (result != null) {
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    static class AnnotationResourceLiteral implements ArquillianResource {
+
+        @Override
+        public Class<?> value() {
+            return ArquillianResource.class;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return ArquillianResource.class;
+        }
+    }
+}

--- a/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/StaticPayaraManagementLookup.java
+++ b/payara-management-api/src/main/java/fish/payara/arquillian/management/impl/StaticPayaraManagementLookup.java
@@ -1,0 +1,70 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.impl;
+
+import fish.payara.arquillian.management.ExternalServerManagement;
+import fish.payara.arquillian.management.ServerManagement;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+public class StaticPayaraManagementLookup {
+    private static final Logger LOGGER = Logger.getLogger(StaticPayaraManagementLookup.class.getName());
+    static volatile Supplier<ExternalServerManagement> externalServerManagemenSupplier;
+    static volatile Supplier<ServerManagement> serverManagementSupplier;
+
+    public static ExternalServerManagement externalServerManagement() {
+        if (externalServerManagemenSupplier == null) {
+            LOGGER.warning("No Arquillian extension provided external server management implementation");
+            return null;
+        }
+        return externalServerManagemenSupplier.get();
+    }
+
+    public static ServerManagement serverManagement() {
+        if (serverManagementSupplier == null) {
+            LOGGER.warning("No Arquillian extension provided server management implementation");
+        }
+        return serverManagementSupplier.get();
+    }
+}

--- a/payara-management-api/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/payara-management-api/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,41 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+#
+
+fish.payara.arquillian.management.impl.PayaraManagementExtension

--- a/payara-management-api/src/test/java/fish/payara/arquillian/management/InjectionTest.java
+++ b/payara-management-api/src/test/java/fish/payara/arquillian/management/InjectionTest.java
@@ -1,0 +1,111 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class InjectionTest {
+    public static ExternalServerManagement instance;
+
+    static boolean instanceAvailableBeforeDeployment;
+    static boolean instanceAvailableInBeforeClass;
+    static boolean instanceAvailableInClassRule;
+    static boolean programmaticInstanceAvailableInClassRule;
+
+    @ArquillianResource
+    ServerManagement management;
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        System.out.println("Class deployment called");
+        instanceAvailableBeforeDeployment = instance != null;
+        return ShrinkWrap.create(JavaArchive.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.out.println("beforeClass called");
+        instanceAvailableInBeforeClass = instance != null;
+    }
+
+    @ClassRule
+    public static ExternalResource classRule = new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            instanceAvailableInClassRule = instance != null;
+            programmaticInstanceAvailableInClassRule = ExternalServerManagement.instance() != null;
+        }
+    };
+
+    @Test
+    @RunAsClient
+    public void externalServerManagementIsAvailable() {
+        assertTrue("ExternalServerManagement instance should be injected in deployment method", instanceAvailableBeforeDeployment);
+        // we happen to run this test in embedded container so we're lucky
+        assertTrue("ExternalServerManagement instance should be injected in embedded container's @BeforeClass", instanceAvailableInBeforeClass);
+        assertFalse("ExternalServerManagement is not injected in @ClassRule, as there's no arquillian callback for that", instanceAvailableInClassRule);
+        assertTrue("ExternalServerManagement instance should be available in @ClassRule via programmatic lookup", programmaticInstanceAvailableInClassRule);
+    }
+
+    @Test
+    public void serverManagementIsAvailable() {
+        assertNotNull("ServerManagement instance should be injected via @AruillianResource", management);
+        assertNotNull("ServerManagement instance can be looked up programmatically", ServerManagement.instance());
+    }
+
+}

--- a/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ClientArchiveAppender.java
+++ b/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ClientArchiveAppender.java
@@ -1,0 +1,65 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.mockimpl;
+
+import fish.payara.arquillian.management.ServerManagement;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * This adds remote extension to client archive
+ */
+public class ClientArchiveAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+             // add extension dependencies
+            .addClass(Common.class)
+            // add and register container extension
+            .addClass(ContainerExtension.class)
+            // in true remote containers, remote extension will do the trick
+            .addAsServiceProvider(RemoteLoadableExtension.class, ContainerExtension.class);
+    }
+}

--- a/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ClientExtension.java
+++ b/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ClientExtension.java
@@ -1,0 +1,101 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.mockimpl;
+
+import fish.payara.arquillian.management.ExternalServerManagement;
+import org.jboss.arquillian.container.spi.event.container.AfterStart;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.InvocationException;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Example of how container implementations should interact with management-api.
+ * A container should register a producers
+ */
+public class ClientExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        // this registers client-side management interface
+        extensionBuilder.observer(ExternalManagementProducer.class);
+
+        // If we'd utilize remote protocol, we'd use these
+        //extensionBuilder.service(AuxiliaryArchiveAppender.class, ClientArchiveAppender.class);
+
+        // but our mock container is embedded one, and therefore we perform client registration right here
+        ContainerExtension quasiContainerExtension = new ContainerExtension();
+        quasiContainerExtension.register(extensionBuilder);
+
+        // debug arquillian events
+        extensionBuilder.observer(Observer.class);
+    }
+
+    static class Observer {
+        @SuppressWarnings("unused")
+        public void whatsUp(@Observes Object o) {
+            System.out.printf("%s: %s\n", o.getClass(), o);
+            if (o instanceof Throwable) {
+                // rethrow, otherwise all tests pass
+                throw new InvocationException((Throwable)o);
+            }
+        }
+
+    }
+
+
+    /**
+     * External management is applied in Arquillian Client Context
+     */
+    static class ExternalManagementProducer {
+        @Inject @ApplicationScoped //application scope is only one active when class rule is invoked
+        InstanceProducer<ExternalServerManagement> externalServerManagementInstanceProducer;
+
+        // likely the best point to inject stuff is after container is started, as it is properly configured
+        // another good point would be AfterSetup, or observing container itself fired as event
+        @SuppressWarnings("unused")
+        public void produce(@Observes AfterStart event) {
+            externalServerManagementInstanceProducer.set(Common.mock(ExternalServerManagement.class));
+        }
+    }
+}

--- a/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/Common.java
+++ b/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/Common.java
@@ -1,0 +1,50 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.mockimpl;
+
+import java.lang.reflect.Proxy;
+
+public class Common {
+    static <T> T mock(Class<T> mockedInterface) {
+        return mockedInterface.cast(Proxy.newProxyInstance(ClientExtension.class.getClassLoader(),
+            new Class[]{mockedInterface}, (proxy, method, args) -> null));
+    }
+}

--- a/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ContainerExtension.java
+++ b/payara-management-api/src/test/java/fish/payara/arquillian/management/mockimpl/ContainerExtension.java
@@ -1,0 +1,85 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.arquillian.management.mockimpl;
+
+import fish.payara.arquillian.management.ServerManagement;
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+public class ContainerExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        System.out.println("Container extension loaded");
+        extensionBuilder.service(ResourceProvider.class, ServerManagementProducer.class);
+    }
+
+
+    /**
+     * Server management is available within container context
+     */
+    static class ServerManagementProducer implements ResourceProvider {
+        static ServerManagement instance = Common.mock(ServerManagement.class);
+
+        // I'm not sure if this is available outside of embedded container, but may help providing additional information
+        // other interesting objects might be
+        // DeploymentDescription, Deployment, container instance class
+        // Injection is only supported for Instance<T>
+        @Inject
+        Instance<Container> manager;
+
+        @Override
+        public boolean canProvide(Class<?> aClass) {
+            return aClass == ServerManagement.class;
+        }
+
+        @Override
+        public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
+            return instance;
+        }
+    }
+}

--- a/payara-management-api/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/payara-management-api/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,41 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+#
+
+fish.payara.arquillian.management.mockimpl.ClientExtension

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
         <module>payara-client-ee8</module>
       <module>payara-micro-deployer</module>
       <module>payara-micro-remote</module>
+      <module>payara-management-api</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Initial draft of server management API and example of an implementation that
should go into each container.

Containers would implement `ExternalServerManagement` (for deploy time / client-side tests) and `ServerManagement` for (server-side tests) and publish those either via Arquillian injection API or resource provisioning API.

The tests then can look up those via programmatic access with method `.instance()` on the interface, or via `@ArquillianResource`