### PR TITLE
AC-45: Fix protocol description of micro managed container

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -89,6 +89,7 @@
             <arquillian.version>${arquillian.version}</arquillian.version>
           </filterProperties>
           <streamLogs>true</streamLogs>
+          <skipInvocation>${skipTests}</skipInvocation>
         </configuration>
         <executions>
           <execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>parent-payara-containers</artifactId>
+    <groupId>fish.payara.arquillian</groupId>
+    <version>1.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>integration-tests</artifactId>
+
+  <properties>
+    <payara.version>5.193.1</payara.version>
+    <arquillian.version>1.5.0.Final</arquillian.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>fish.payara.arquillian</groupId>
+      <artifactId>arquillian-payara-server-embedded</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>fish.payara.arquillian</groupId>
+      <artifactId>arquillian-payara-server-managed</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>fish.payara.arquillian</groupId>
+      <artifactId>arquillian-payara-micro-managed</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <filterProperties>
+            <payara.version>${payara.version}</payara.version>
+            <arquillian.version>${arquillian.version}</arquillian.version>
+          </filterProperties>
+          <streamLogs>true</streamLogs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-tests/src/it/microprofile/invoker.properties
+++ b/integration-tests/src/it/microprofile/invoker.properties
@@ -1,0 +1,52 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+#
+
+invoker.goals=clean verify
+invoker.name.1=Embedded
+invoker.profiles.1=payara-server-embedded
+
+invoker.name.2=Managed
+invoker.profiles.2=payara-server-managed
+
+invoker.name.3=Micro (jar copied)
+invoker.profiles.3=payara-micro-managed-copied
+
+invoker.name.4=Micro (classpath)
+invoker.profiles.4=payara-micro-managed-classpath

--- a/integration-tests/src/it/microprofile/pom.xml
+++ b/integration-tests/src/it/microprofile/pom.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>fish.payara.arquillian.test</groupId>
+  <artifactId>microprofile-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>@arquillian.version@</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- That's you core dependency for all Jakarta EE APIs (scope provided) -->
+    <dependency>
+      <groupId>jakarta.platform</groupId>
+      <artifactId>jakarta.jakartaee-api</artifactId>
+      <version>8.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- This is aggregate dependency of all Microprofile APIs.
+         Even that artifact is also usable as BOM, the version in dependencyManagement
+         cannot be set by import, but this is also convenient use that brings all apis in provided scope. -->
+    <dependency>
+      <groupId>org.eclipse.microprofile</groupId>
+      <artifactId>microprofile</artifactId>
+      <type>pom</type>
+      <version>2.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <properties>
+    <!-- This is Java 8 project -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <container.version>@project.version@</container.version>
+    <payara.version>@payara.version@</payara.version>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <!-- EE 7+ compliant war plugin (no web.xml needed) -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.2.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!-- Run integration tests -->
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <failIfNoTests>true</failIfNoTests>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>payara-server-embedded</id>
+      <dependencies>
+        <dependency>
+          <groupId>fish.payara.arquillian</groupId>
+          <artifactId>arquillian-payara-server-embedded</artifactId>
+          <version>${container.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>fish.payara.extras</groupId>
+          <artifactId>payara-embedded-all</artifactId>
+          <version>${payara.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <!-- don't mix compile-time apis and bundled server apis -->
+              <classpathDependencyScopeExclude>compile</classpathDependencyScopeExclude>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>payara-server-managed</id>
+      <dependencies>
+        <dependency>
+          <groupId>fish.payara.arquillian</groupId>
+          <artifactId>arquillian-payara-server-managed</artifactId>
+          <version>${container.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <!-- download and unpack payara server -->
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                  <markersDirectory>
+                    ${session.executionRootDirectory}/target/dependency-maven-plugin-markers
+                  </markersDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>fish.payara.distributions</groupId>
+                      <artifactId>payara</artifactId>
+                      <type>zip</type>
+                      <version>${payara.version}</version>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- pass server location to test -->
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <!-- Pass location of server installation to arquillian container -->
+                <GLASSFISH_HOME>${session.executionRootDirectory}/target/payara5</GLASSFISH_HOME>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>payara-micro-managed-copied</id>
+      <dependencies>
+
+        <dependency>
+          <groupId>fish.payara.arquillian</groupId>
+          <artifactId>arquillian-payara-micro-managed</artifactId>
+          <version>${container.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <!-- download and unpack payara micro -->
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>fish.payara.extras</groupId>
+                      <artifactId>payara-micro</artifactId>
+                      <version>${payara.version}</version>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                  <stripVersion>true</stripVersion>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- pass location to test -->
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemProperties>
+                <payara.microJar>target/payara-micro.jar</payara.microJar>
+              </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>payara-micro-managed-classpath</id>
+      <dependencies>
+
+        <dependency>
+          <groupId>fish.payara.arquillian</groupId>
+          <artifactId>arquillian-payara-micro-managed</artifactId>
+          <version>${container.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>fish.payara.extras</groupId>
+          <artifactId>payara-micro</artifactId>
+          <version>${payara.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+
+    </profile>
+  </profiles>
+
+
+</project>

--- a/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/DemoRestApplication.java
+++ b/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/DemoRestApplication.java
@@ -1,0 +1,53 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ *
+ */
+@ApplicationPath("/data")
+@ApplicationScoped
+public class DemoRestApplication extends Application {
+}

--- a/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/HelloController.java
+++ b/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/HelloController.java
@@ -1,0 +1,58 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ *
+ */
+@Path("/hello")
+@Singleton
+public class HelloController {
+
+    @GET
+    public String sayHello() {
+        return "Hello World";
+    }
+}

--- a/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/config/ConfigTestController.java
+++ b/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/config/ConfigTestController.java
@@ -1,0 +1,73 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo.config;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/config")
+@RequestScoped
+public class ConfigTestController {
+
+    @Inject
+    @ConfigProperty(name = "injected.value")
+    private String injectedValue;
+
+    @Path("/injected")
+    @GET
+    public String getInjectedConfigValue() {
+        return "Config value as Injected by CDI " + injectedValue;
+    }
+
+    @Path("/lookup")
+    @GET
+    public String getLookupConfigValue() {
+        Config config = ConfigProvider.getConfig();
+        String value = config.getValue("value", String.class);
+        return "Config value from ConfigProvider " + value;
+    }
+}

--- a/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/health/ServiceHealthCheck.java
+++ b/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/health/ServiceHealthCheck.java
@@ -1,0 +1,59 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo.health;
+
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@Health
+@ApplicationScoped
+public class ServiceHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+
+        return HealthCheckResponse.named(ServiceHealthCheck.class.getSimpleName()).up().build();
+
+    }
+}

--- a/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/metric/MetricController.java
+++ b/integration-tests/src/it/microprofile/src/main/java/fish/payara/bomdemo/metric/MetricController.java
@@ -1,0 +1,93 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo.metric;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.Random;
+
+@Path("/metric")
+@ApplicationScoped //Required for @Gauge
+public class MetricController {
+
+    @Inject
+    @Metric(name = "endpoint_counter")
+
+    private Counter counter;
+
+    @Path("timed")
+    @Timed(name = "timed-request")
+    @GET
+    public String timedRequest() {
+        // Demo, not production style
+        int wait = new Random().nextInt(1000);
+        try {
+            Thread.sleep(wait);
+        } catch (InterruptedException e) {
+            // Demo
+            e.printStackTrace();
+        }
+
+        return "Request is used in statistics, check with the Metrics call.";
+    }
+
+
+    @Path("increment")
+    @GET
+    public long doIncrement() {
+        counter.inc();
+        return counter.getCount();
+    }
+
+    @Gauge(name = "counter_gauge", unit = MetricUnits.NONE)
+    private long getCustomerCount() {
+        return counter.getCount();
+    }
+}

--- a/integration-tests/src/it/microprofile/src/main/resources/META-INF/microprofile-config.properties
+++ b/integration-tests/src/it/microprofile/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+injected.value=Injected value
+value=lookup value

--- a/integration-tests/src/it/microprofile/src/test/java/fish/payara/bomdemo/WholeAppIT.java
+++ b/integration-tests/src/it/microprofile/src/test/java/fish/payara/bomdemo/WholeAppIT.java
@@ -1,0 +1,151 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.bomdemo;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class WholeAppIT {
+    @Deployment
+    public static WebArchive deployWholeApp() throws IOException {
+        Path packageResult = Files.list(Paths.get("target"))
+                .filter(p -> p.getFileName().toString().endsWith(".war"))
+                .findAny().orElseThrow(() -> new IllegalStateException("No .war file in target directory. Run 'mvn verify'"));
+        return ShrinkWrap.createFromZipFile(WebArchive.class, packageResult.toFile());
+    }
+
+    @ArquillianResource
+    URI baseUrl;
+
+    @Test
+    public void helloControllerGreets() {
+        String greeting = ClientBuilder.newClient().target(baseUrl).path("data/hello").request().get(String.class);
+        assertEquals("Hello World", greeting);
+    }
+
+    @Test
+    public void healthCheckUp() {
+        WebTarget healthPath = ClientBuilder.newClient().target(baseUrl.resolve("/")).path("health");
+        JsonObject health = healthPath
+                .request(MediaType.APPLICATION_JSON_TYPE).get(JsonObject.class);
+        assertNotNull(health);
+        System.out.println(health);
+        // response changed with Health 2.2 / 5.194, so let's not go into details of the message
+    }
+
+    @Test
+    public void metricMeasures() {
+        Client client = ClientBuilder.newClient();
+        WebTarget metricEndpoint = client.target(baseUrl).path("data/metric");
+
+        long counter = metricEndpoint.path("increment").request().get(Long.class);
+        assertTrue("counter should be at least 1, is "+counter, counter > 0);
+
+        WebTarget metricsPath = client.target(baseUrl.resolve("/")).path("metrics");
+        JsonObject metrics = metricsPath
+                .request(MediaType.APPLICATION_JSON_TYPE).get(JsonObject.class);
+        assertNotNull(metrics);
+        /*
+         {
+          "vendor": {
+            "system.cpu.load": 0.6216716209333485
+          },
+          "base": {
+            // ...
+          },
+          "application": {
+            "fish.payara.bomdemo.metric.MetricController.endpoint_counter": 1,
+            "fish.payara.bomdemo.metric.MetricController.timed-request": {
+              "fiveMinRate": 0.0,
+              "max": 0,
+              "count": 0,
+              "p50": 0.0,
+              "p95": 0.0,
+              "p98": 0.0,
+              "p75": 0.0,
+              "p99": 0.0,
+              "min": 0,
+              "fifteenMinRate": 0.0,
+              "meanRate": 0.0,
+              "mean": 0.0,
+              "p999": 0.0,
+              "oneMinRate": 0.0,
+              "stddev": 0.0
+            }
+          }
+        }
+        */
+        assertEquals(counter, metrics.getJsonObject("application").getJsonNumber("fish.payara.bomdemo.metric.MetricController.endpoint_counter").longValue());
+        assertNotNull(metrics.getJsonObject("application").getJsonObject("fish.payara.bomdemo.metric.MetricController.timed-request"));
+    }
+
+    @Test
+    public void configConfigures() {
+        Client client = ClientBuilder.newClient();
+        WebTarget configEndpoint = client.target(baseUrl).path("data/config/");
+
+        String configResult = configEndpoint.path("injected").request().get(String.class);
+        assertEquals("Config value as Injected by CDI Injected value", configResult);
+    }
+}

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -41,6 +41,7 @@ import static org.jboss.arquillian.container.spi.client.deployment.Validate.notN
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Properties;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
@@ -73,11 +74,25 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
     private String cmdOptions = getConfigurableVariable("payara.cmdOptions", "MICRO_CMD_OPTIONS", null);
 
     private String extraMicroOptions = getConfigurableVariable("payara.extraMicroOptions", "EXTRA_MICRO_OPTIONS", null);
+
+    private boolean microOnClasspath;
     
     private final String ZIP_ENTRY_FILE_DIR = "MICRO-INF/domain/branding/glassfish-version.properties";
 
     public String getMicroJar() {
+        if (microJar == null) {
+            URL microUrl = getClass().getClassLoader().getResource("fish/payara/micro/PayaraMicro.class");
+            if (microUrl != null && microUrl.getProtocol().equals("jar") && microUrl.getPath().startsWith("file:")) {
+                String path = microUrl.getPath();
+                microOnClasspath = true;
+                microJar = path.substring(5, path.indexOf('!'));
+            }
+        }
         return microJar;
+    }
+
+    boolean isMicroOnClasspath() {
+        return microOnClasspath;
     }
 
     public File getMicroJarFile() {

--- a/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -131,7 +131,7 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
 
     @Override
     public ProtocolDescription getDefaultProtocol() {
-        return new ProtocolDescription("Servlet 4.0");
+        return new ProtocolDescription("Servlet 3.0");
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
         <module>payara-client-ee8</module>
       <module>payara-micro-deployer</module>
       <module>payara-micro-remote</module>
+      <module>integration-tests</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes #32.

I had also small feature lying around, that drops the need for copying payara micro into known location, it's enough, when it's runtime-scoped dependency.

Added tests for both uses into new top-level module `integration-tests`. This will allow to put in more diverse test cases for using the container by means of Maven invoker plugin.