### PR TITLE
QACI-78 Use instanceof rather than equals()

### DIFF
--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
@@ -396,7 +396,7 @@ public class PayaraClientService implements PayaraClient {
         try {
             getClientUtil().GETRequest("");
         } catch (ProcessingException clientEx) {
-            if (clientEx.getCause()!= null && clientEx.getCause().getClass().equals(ConnectException.class)) {
+            if (clientEx.getCause()!= null && clientEx.getCause() instanceof ConnectException) {
                 // We were unable to connect to the DAS through Jersey
                 return false;
             }


### PR DESCRIPTION
equals() checks exact class, whereas we're getting a subclass back.