### PR TITLE
Fixing CDI TCK deployment problems

### DIFF
--- a/payara-micro-remote/pom.xml
+++ b/payara-micro-remote/pom.xml
@@ -97,5 +97,11 @@
             <artifactId>javax.json</artifactId>
             <version>1.1.4</version>
         </dependency>
+        
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>2.0.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/payara-micro-remote/src/main/java/fish/payara/arquillian/container/payaramicro/remote/DeployerClient.java
+++ b/payara-micro-remote/src/main/java/fish/payara/arquillian/container/payaramicro/remote/DeployerClient.java
@@ -80,10 +80,10 @@ class DeployerClient {
                 JsonObject json = Json.createReader(httpConnection.getErrorStream()).readObject();
                 String message = json.getString("message", null);
                 if (message != null) {
-                    if (message.startsWith("CDI definition failure")) {
-                        throw new DefinitionException("Deployment failed. " + this + " returned " + responseCode);
-                    } else if (message.startsWith("CDI deployment failure")) {
+                    if (message.startsWith("CDI deployment failure") || message.contains("org.jboss.weld.exceptions.DeploymentException")) {
                         throw new DeploymentException("Deployment failed. " + this + " returned " + responseCode);
+                    } else if (message.startsWith("CDI definition failure")) {
+                        throw new DefinitionException("Deployment failed. " + this + " returned " + responseCode);
                     }
                 }
                 throw new IllegalArgumentException("Deployment failed. " + this + " returned " + responseCode);


### PR DESCRIPTION
Enhances the `payara-micro-remote` Arquillian connector to read the message in case of deployment failure and throw appropriate CDI exception expected by the CDI TCK.

Enhances the associated `payara-micro-deployer` to capture deployment exception messages from log and report them as the `message` field in the JSON response instead of the default message so that the Arquillian connector has enough information to detect the exception type.

