### PR TITLE
[QACI-637] Sequenced deployment names and optionally serialize deployments for parallel testing

### DIFF
--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -134,7 +134,7 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
         final String deploymentName = createDeploymentName(prependDeploySequence ?
                 String.format("r%d-%s", deploySequence.incrementAndGet(), archiveName) : archiveName);
 
-        log.log(Level.INFO, "Deploying {0}", new Object[] { deploymentName });
+        log.log(Level.FINE, "Deploying {0}", new Object[] { deploymentName });
 
         final ProtocolMetaData protocolMetaData = new ProtocolMetaData();
 

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -74,7 +74,7 @@ import fish.payara.arquillian.container.payara.clientutils.PayaraClient;
 import fish.payara.arquillian.container.payara.clientutils.PayaraClientException;
 import fish.payara.arquillian.container.payara.clientutils.PayaraClientService;
 import java.io.IOException;
-import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
@@ -95,14 +95,14 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
 
     private static final String DELETE_OPERATION = "__deleteoperation";
     private static final Lock deployLock;
-    private static final boolean prependRandomToDeploymentName;
+    private static final boolean prependDeploySequence;
 
     private final C configuration;
     private final PayaraClient payaraClient;
-    private final Random random = new Random();
+    private final AtomicInteger deploySequence = new AtomicInteger();
 
     static {
-        prependRandomToDeploymentName = Boolean.getBoolean("fish.payara.arquillian.prependRandom");
+        prependDeploySequence = Boolean.getBoolean("fish.payara.arquillian.prependDeploySequence");
         deployLock = Boolean.getBoolean("fish.payara.arquillian.deployLock") ? new ReentrantLock() : new NoOpLock();
         if (deployLock instanceof ReentrantLock) {
             log.info("Serializing Deployments and Undeployments (fish.payara.arquillian.deployLock)");
@@ -131,8 +131,8 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
         }
 
         final String archiveName = archive.getName();
-        final String deploymentName = createDeploymentName(prependRandomToDeploymentName ?
-                String.format("r%d-%s", random.nextInt(1000), archiveName) : archiveName);
+        final String deploymentName = createDeploymentName(prependDeploySequence ?
+                String.format("r%d-%s", deploySequence.incrementAndGet(), archiveName) : archiveName);
 
         log.log(Level.INFO, "Deploying {0}", new Object[] { deploymentName });
 

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/NoOpLock.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/NoOpLock.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.arquillian.container.payara;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * @author lprimak
+ */
+class NoOpLock implements Lock {
+    @Override
+    public void lock() {
+        // no-op
+    }
+
+    @Override
+    public void unlock() {
+        // no-op
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public boolean tryLock() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public Condition newCondition() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+}

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
@@ -391,7 +391,7 @@ public class PayaraClientService implements PayaraClient {
     @Override
     public Map<String, Object> doUndeploy(String name, FormDataMultiPart form) {
         name = unregisterDeployedName(name);
-        log.log(Level.INFO, "Undeploying {0}", new Object[] { name });
+        log.log(Level.FINE, "Undeploying {0}", new Object[] { name });
         return getClientUtil().POSTMultiPartRequest(name, APPLICATION_RESOURCE.replace("{name}", name), form);
     }
 

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/clientutils/PayaraClientService.java
@@ -391,6 +391,7 @@ public class PayaraClientService implements PayaraClient {
     @Override
     public Map<String, Object> doUndeploy(String name, FormDataMultiPart form) {
         name = unregisterDeployedName(name);
+        log.log(Level.INFO, "Undeploying {0}", new Object[] { name });
         return getClientUtil().POSTMultiPartRequest(name, APPLICATION_RESOURCE.replace("{name}", name), form);
     }
 


### PR DESCRIPTION
- added `fish.payara.arquillian.prependDeploySequence`
 system property (boolean)
 to randomize deployment names so they don't clash during parallel testing

- added `fish.payara.arquillian.deployLock` system property (boolean) to serialize deployments
  during parallel testing, alleviating pressure on Payara's deployment system