### PR TITLE
FISH-1060 Throw a DeploymentException as DeploymentException

### DIFF
--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -63,6 +63,7 @@ import java.util.logging.Logger;
 
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
+import org.glassfish.jersey.server.ContainerException;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
@@ -156,6 +157,13 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
             protocolMetaData.addContext(httpContext);
         } catch (PayaraClientException | IOException e) {
             throw new DeploymentException("Could not deploy " + archiveName, e);
+        } catch (ContainerException containerException) {
+            // The deploy command doesn't return the exception itself, so inspect the message for a DeploymentException
+            // and pass this on for the MicroProfile TCKs
+            if (containerException.getMessage().contains("javax.enterprise.inject.spi.DeploymentException: " +
+                "Deployment Failure for")) {
+                throw new javax.enterprise.inject.spi.DeploymentException(containerException);
+            }
         }
 
         return protocolMetaData;

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -164,6 +164,7 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
                 "Deployment Failure for")) {
                 throw new javax.enterprise.inject.spi.DeploymentException(containerException);
             }
+            throw containerException;
         }
 
         return protocolMetaData;


### PR DESCRIPTION
Line endings are messed up.
Actual change is catching a container exception on deployment, and checking its message for if it's a deployment exception - if it is, throw it as such.

The MicroProfile Config TCK currently expects a DeploymentException (javax kind, not arquillian kind), but the deploy command doesn't return the actual exception when it fails, just a message with a stacktrace. An alternative fix would be to rework Payara so that it attaches the actual exception as an extra property in its response.