### PR TITLE
FISH-1518 Check for and rethrow FT exceptions as FT exceptions

### DIFF
--- a/payara-common/pom.xml
+++ b/payara-common/pom.xml
@@ -148,6 +148,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+            <artifactId>microprofile-fault-tolerance-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -61,6 +61,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import java.io.InputStream;
 import java.util.logging.Logger;
 
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 import org.glassfish.jersey.server.ContainerException;
@@ -163,6 +164,9 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
             if (containerException.getMessage().contains("javax.enterprise.inject.spi.DeploymentException: " +
                 "Deployment Failure for")) {
                 throw new javax.enterprise.inject.spi.DeploymentException(containerException);
+            } else if (containerException.getMessage().contains(
+                "org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException: Method")) {
+                throw new FaultToleranceDefinitionException(containerException);
             }
             throw containerException;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <version.maven.shade.plugin>3.2.4</version.maven.shade.plugin>
         <version.maven.enforcer.plugin>3.0.0-M2</version.maven.enforcer.plugin>
         <version.maven.deploy.plugin>3.0.0-M1</version.maven.deploy.plugin>
+        <version.microprofile.fault-tolerance>3.0</version.microprofile.fault-tolerance>
 
         <version.java>1.8</version.java>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -253,6 +254,12 @@
                 <version>${version.arquillian_core}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+                <artifactId>microprofile-fault-tolerance-api</artifactId>
+                <version>${version.microprofile.fault-tolerance}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Workaround fix to rethrow FaultToleranceDefinitionExceptions as that specific type, to allow the Fault Tolerance TCK to work. The "proper" fix for this is liable to be a pain and have ramifications since it entails changing the way the deploy command works and checking for serialisation issues when using the DeploymentException class in Payara, and then amending the error handling on this side to not wrap certain exceptions as ContainerExceptions.

Signed-off-by: Andrew Pielage <pandrex247@hotmail.com>