### PR TITLE
FISH-778 Allow Defining System Properties for the Server

### DIFF
--- a/payara-embedded/src/main/java/fish/payara/arquillian/container/payara/embedded/PayaraConfiguration.java
+++ b/payara-embedded/src/main/java/fish/payara/arquillian/container/payara/embedded/PayaraConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -86,6 +86,7 @@ public class PayaraConfiguration implements ContainerConfiguration {
     private String configurationXml;
     private String resourcesXml;
     private boolean cleanup = true;
+    private String serverSystemProperties;
 
     @Override
     public void validate() throws ConfigurationException {
@@ -199,6 +200,24 @@ public class PayaraConfiguration implements ContainerConfiguration {
      */
     public void setResourcesXml(String resourcesXml) {
         this.resourcesXml = resourcesXml;
+    }
+
+    /**
+     * Sets the system properties to create on the embedded Payara Server instance. Should take the form of one or more
+     * 'key=value' delimited by ':'.
+     *
+     * @return The colon separated string of 'key=value' to pass to the create-system-properties command
+     */
+    public String getServerSystemProperties() {
+        return serverSystemProperties;
+    }
+
+    /**
+     * Sets the system properties to create on the embedded Payara Server instance. Should take the form of one or more
+     * 'key=value' delimited by ':'.
+     */
+    public void setServerSystemProperties(String serverSystemProperties) {
+        this.serverSystemProperties = serverSystemProperties;
     }
 
     /**

--- a/payara-embedded/src/main/java/fish/payara/arquillian/container/payara/embedded/PayaraContainer.java
+++ b/payara-embedded/src/main/java/fish/payara/arquillian/container/payara/embedded/PayaraContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -198,6 +198,15 @@ public class PayaraContainer implements DeployableContainer<PayaraConfiguration>
             bindCommandRunner();
         } catch (Exception e) {
             throw new LifecycleException("Could not start GlassFish Embedded", e);
+        }
+
+        String serverSystemProperties = configuration.getServerSystemProperties();
+        if (serverSystemProperties != null && !serverSystemProperties.equals("")) {
+            try {
+                executeCommand("create-system-properties", serverSystemProperties);
+            } catch (Throwable throwable) {
+                throw new RuntimeException("Error creating system properties: " + serverSystemProperties, throwable);
+            }
         }
         
         // Server needs to be started before we can deploy resources

--- a/payara-embedded/src/test/java/fish/payara/arquillian/container/payara/embedded/app/AsAdminCommandTestCase.java
+++ b/payara-embedded/src/test/java/fish/payara/arquillian/container/payara/embedded/app/AsAdminCommandTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -70,6 +70,7 @@ import org.glassfish.embeddable.CommandRunner;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -116,5 +117,11 @@ public class AsAdminCommandTestCase {
         assertEquals("Verify asadmin command 'ping-connection-pool'", SUCCESS, result.getExitStatus());
 
         assertNotNull(new InitialContext().lookup("jdbc/my_database"));
+    }
+
+    @Test
+    public void serverSystemPropertiesShouldBeSet() {
+        CommandResult result = commandRunner.run("list-system-properties");
+        Assert.assertTrue(result.getOutput().contains("bibbly=bobbly") && result.getOutput().contains("wibbly=wobbly"));
     }
 }

--- a/payara-embedded/src/test/resources/arquillian.xml
+++ b/payara-embedded/src/test/resources/arquillian.xml
@@ -12,6 +12,7 @@
       </property>
       <property name="bindHttpPort">7070</property>
       <property name="bindHttpsPort">7071</property>
+      <property name="serverSystemProperties">wibbly=wobbly:bibbly=bobbly</property>
     </configuration>
   </container>
 </arquillian>


### PR DESCRIPTION
Allows you to define a ':' delimited string of key=value properties that will be created on the embedded server.
