### PR TITLE
FISH-5984 Invoke create-system-properties command in managed server (Payara 6)

### DIFF
--- a/payara-managed/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraManagedContainerConfiguration.java
+++ b/payara-managed/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraManagedContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -79,6 +79,7 @@ public class PayaraManagedContainerConfiguration extends CommonPayaraConfigurati
     private boolean outputToConsole = true;
     private boolean allowConnectingToRunningServer;
     private boolean enableH2;
+    private String serverSystemProperties;
 
     public String getPayaraHome() {
         return payaraHome;
@@ -128,6 +129,29 @@ public class PayaraManagedContainerConfiguration extends CommonPayaraConfigurati
      */
     public void setEnableH2(boolean enableH2) {
         this.enableH2 = enableH2;
+    }
+
+    /**
+     * Sets the system properties to create on the managed Payara Server
+     * instance. Should take the form of one or more 'key=value' delimited by
+     * ':'.
+     *
+     * @return The colon separated string of 'key=value' to pass to the
+     * create-system-properties command
+     */
+    public String getServerSystemProperties() {
+        return serverSystemProperties;
+    }
+
+    /**
+     * Sets the system properties to create on the managed Payara Server
+     * instance.Should take the form of one or more 'key=value' delimited by
+     * ':'.
+     *
+     * @param serverSystemProperties
+     */
+    public void setServerSystemProperties(String serverSystemProperties) {
+        this.serverSystemProperties = serverSystemProperties;
     }
 
     @Override

--- a/payara-managed/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraServerControl.java
+++ b/payara-managed/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraServerControl.java
@@ -123,16 +123,37 @@ class PayaraServerControl {
         String serverSystemProperties = null;
         final Properties props = new Properties();
         try (InputStream istrm = Thread.currentThread().getContextClassLoader().getResourceAsStream("system-properties.properties")) {
-            props.load(istrm);
+            if (istrm != null) {
+                props.load(istrm);
+            }
             serverSystemProperties = props.stringPropertyNames()
                     .stream()
                     .map(key -> key + "=" + props.getProperty(key))
                     .collect(Collectors.joining(":"));
             if (serverSystemProperties != null && !serverSystemProperties.equals("")) {
-                executeAdminCommand("create-system-properties", "create-system-properties", Collections.singletonList(serverSystemProperties), createProcessOutputConsumer());
+                executeAdminCommand(
+                        "create-system-properties from system-properties.properties",
+                        "create-system-properties",
+                        Collections.singletonList(serverSystemProperties),
+                        createProcessOutputConsumer()
+                );
             }
         } catch (Throwable t) {
-            throw new RuntimeException("Error creating system properties: " + serverSystemProperties, t);
+            throw new RuntimeException("Error creating system properties from system-properties.properties: " + Thread.currentThread().getContextClassLoader().getResourceAsStream("system-properties.properties") + serverSystemProperties, t);
+        }
+
+        serverSystemProperties = config.getServerSystemProperties();
+        if (serverSystemProperties != null && !serverSystemProperties.equals("")) {
+            try {
+                executeAdminCommand(
+                        "create-system-properties from serverSystemProperties config",
+                        "create-system-properties",
+                        Collections.singletonList(serverSystemProperties),
+                        createProcessOutputConsumer()
+                );
+            } catch (Throwable t) {
+                throw new RuntimeException("Error creating system properties from serverSystemProperties config: " + serverSystemProperties, t);
+            }
         }
     }
 


### PR DESCRIPTION
This PR add supports creating system properties in managed server instance from the `system-properties.properties` file and/or `serverSystemProperties` config.