### PR TITLE
FISH-8905 - run pipeline for Payara4

### DIFF
--- a/.github/workflows/verify_pr.yml
+++ b/.github/workflows/verify_pr.yml
@@ -1,0 +1,50 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Verify PR
+
+on:
+  pull_request:
+    branches: [ master, Payara6, Payara4, Payara7 ]
+    paths-ignore:
+      - 'README.*'
+      - '**/README.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: 8
+
+    - name: Cache repository
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Clean snapshot dependencies
+      run: "test -d ~/.m2/repository && find ~/.m2/repository/ -name '*-SNAPSHOT' -type d -print0 | xargs -0 rm -r"
+      continue-on-error: true
+
+    - name: Build with Maven
+      env:
+        MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.rto=30000 -Djava.net.preferIPv4Stack=true
+      run: mvn -B -V clean verify
+
+    - name: Archive logs on failure
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs
+        path: "**/*.log"


### PR DESCRIPTION
Integration-tests are not in Payara4, and may need some work to adapt them to that branch. This PR only adds the workflow verify_pr for Payara4, building and testing the submodules.