### PR TITLE
FISH-10780 Optional deploy name param

### DIFF
--- a/environment-setup/pom.xml
+++ b/environment-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>environment-setup</artifactId>

--- a/environment-setup/pom.xml
+++ b/environment-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>environment-setup</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests</artifactId>

--- a/payara-client-ee11/pom.xml
+++ b/payara-client-ee11/pom.xml
@@ -44,7 +44,7 @@
 
     <groupId>fish.payara.arquillian</groupId>
     <artifactId>payara-client-ee11</artifactId>
-    <version>4.0.alpha2</version>
+    <version>4.0.alpha3-SNAPSHOT</version>
     <name>Payara EE 11 client libs</name>
     
     <description>

--- a/payara-client-ee11/pom.xml
+++ b/payara-client-ee11/pom.xml
@@ -44,7 +44,7 @@
 
     <groupId>fish.payara.arquillian</groupId>
     <artifactId>payara-client-ee11</artifactId>
-    <version>4.0.alpha3-SNAPSHOT</version>
+    <version>4.0.alpha3</version>
     <name>Payara EE 11 client libs</name>
     
     <description>

--- a/payara-common/pom.xml
+++ b/payara-common/pom.xml
@@ -65,7 +65,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>payara-container-common</artifactId>

--- a/payara-common/pom.xml
+++ b/payara-common/pom.xml
@@ -65,7 +65,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>payara-container-common</artifactId>

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraConfiguration.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -86,6 +86,7 @@ public class CommonPayaraConfiguration implements ContainerConfiguration {
     private String domain;
     protected boolean debug;
     private boolean httpsEnabled = Boolean.getBoolean("httpsEnabled");
+    private final boolean addDeployName = Boolean.getBoolean("addDeployName");
 
     public CommonPayaraConfiguration() {
         super();
@@ -304,5 +305,9 @@ public class CommonPayaraConfiguration implements ContainerConfiguration {
             Validate.notNull(getAdminUser(), "adminUser must be specified to use authorisation");
             Validate.notNull(getAdminPassword(), "adminPassword must be specified to use authorisation");
         }
+    }
+
+    public boolean isAddDeployName() {
+        return addDeployName;
     }
 }

--- a/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
+++ b/payara-common/src/main/java/fish/payara/arquillian/container/payara/CommonPayaraManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2025] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -236,7 +236,9 @@ public class CommonPayaraManager<C extends CommonPayaraConfiguration> {
     private void addDeployFormFields(String name, PayaraClient.MultiPart deployform) {
 
         // Add the name field, the name is the archive filename without extension
-        deployform.field("name", name, TEXT_PLAIN_TYPE);
+        if (configuration.isAddDeployName()) {
+            deployform.field("name", name, TEXT_PLAIN_TYPE);
+        }
 
         // Add the target field (the default is "server" - Admin Server)
         deployform.field("target", configuration.getTarget(), TEXT_PLAIN_TYPE);

--- a/payara-embedded/pom.xml
+++ b/payara-embedded/pom.xml
@@ -63,7 +63,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>arquillian-payara-server-embedded</artifactId>

--- a/payara-embedded/pom.xml
+++ b/payara-embedded/pom.xml
@@ -63,7 +63,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-payara-server-embedded</artifactId>

--- a/payara-managed/pom.xml
+++ b/payara-managed/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-payara-server-managed</artifactId>

--- a/payara-managed/pom.xml
+++ b/payara-managed/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>arquillian-payara-server-managed</artifactId>

--- a/payara-micro-deployer/pom.xml
+++ b/payara-micro-deployer/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/payara-micro-deployer/pom.xml
+++ b/payara-micro-deployer/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/payara-micro-remote/pom.xml
+++ b/payara-micro-remote/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/payara-micro-remote/pom.xml
+++ b/payara-micro-remote/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>parent-payara-containers</artifactId>
         <groupId>fish.payara.arquillian</groupId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/payara-micro/pom.xml
+++ b/payara-micro/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>arquillian-payara-micro-managed</artifactId>

--- a/payara-micro/pom.xml
+++ b/payara-micro/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-payara-micro-managed</artifactId>

--- a/payara-remote/pom.xml
+++ b/payara-remote/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha2</version>
+        <version>4.0.alpha3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-payara-server-remote</artifactId>

--- a/payara-remote/pom.xml
+++ b/payara-remote/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>fish.payara.arquillian</groupId>
         <artifactId>parent-payara-containers</artifactId>
-        <version>4.0.alpha3-SNAPSHOT</version>
+        <version>4.0.alpha3</version>
     </parent>
 
     <artifactId>arquillian-payara-server-remote</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
     <groupId>fish.payara.arquillian</groupId>
     <artifactId>parent-payara-containers</artifactId>
-    <version>4.0.alpha3-SNAPSHOT</version>
+    <version>4.0.alpha3</version>
     <packaging>pom</packaging>
 
     <name>Arquillian Container Parent Payara</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
     <groupId>fish.payara.arquillian</groupId>
     <artifactId>parent-payara-containers</artifactId>
-    <version>4.0.alpha2</version>
+    <version>4.0.alpha3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Arquillian Container Parent Payara</name>


### PR DESCRIPTION
This adds a new property to make the 'name' field optional when deploying an application via arquillian.

This fixes the remaining ejb tck failures as you cannot specify an additional name due to this parameter being present.

SNAPSHOT is in nexus